### PR TITLE
Fixing 'key too long' error

### DIFF
--- a/website/laravel/app/Providers/AppServiceProvider.php
+++ b/website/laravel/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -15,6 +16,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+
+        Schema::defaultStringLength(191);
+
         Blade::if('isAdmin', function(){
 
             if (Auth::check()) 


### PR DESCRIPTION
Was unable to open webpage properly without adding:

use Illuminate\Support\Facades\Schema;

public function boot()
{
    Schema::defaultStringLength(191);
}